### PR TITLE
Fixed command to create venv

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ python --version
 Make sure you have [venv](https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/) installed and create a new virtual environment in the folder where you have cloned the repository:
 
 ```bash
-python3 -m venv env
+python -m venv env
 ```
 
 > [!NOTE]


### PR DESCRIPTION
I noticed while following this tutorial that there was a typo in the command to create a new virtual environment (venv). 

In the original code, we have the command `python3 -m venv env` and now I fixed it to `python -m venv env`.

